### PR TITLE
Add ``.k(b)``/``.kill (both)`` Command and Minor Improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         java-version: 1.16
+        distribution: temurin
     - name: Build with Maven
       run: mvn -B package --file pom.xml
     - name: Upload artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 1.16
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
         java-version: 1.16
     - name: Build with Maven
       run: mvn -B package --file pom.xml
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: AutoPlug-Plugin
+        path: target/AutoPlug-Plugin.jar
       
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up JDK 1.16
+    - name: Set up JDK 16
       uses: actions/setup-java@v4
       with:
-        java-version: 1.16
+        java-version: 16
         distribution: temurin
     - name: Build with Maven
       run: mvn -B package --file pom.xml

--- a/README.md
+++ b/README.md
@@ -51,6 +51,26 @@ commands:
     description: Stops the server and the AutoPlug-Client. (Shortcut)
     usage: /.stb
     permission: autoplug.plugin.stopboth
+
+  .kill:
+    description: Kills the server.
+    usage: /.kill
+    permission: autoplug.plugin.kill
+
+  .k:
+    description: Kills the server. (Shortcut)
+    usage: /.k
+    permission: autoplug.plugin.kill
+    
+  .kill both:
+    description: Kills the server and the AutoPlug-Client.
+    usage: /.kill both
+    permission: autoplug.plugin.killboth
+
+  .kb:
+    description: Kills the server and the AutoPlug-Client. (Shortcut)
+    usage: /.kb
+    permission: autoplug.plugin.killboth
 ```
 
 ## AutoPlug-Plugin | Contribute

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <groupId>online.autoplug.plugin</groupId>
     <artifactId>autoplug-plugin</artifactId>
-    <version>1.1</version>
+    <version>1.2</version>
     <packaging>jar</packaging>
 
     <name>AutoPlug-Plugin</name>

--- a/src/main/java/com/osiris/autoplug/plugin/AutoPlugCommandsGUI.java
+++ b/src/main/java/com/osiris/autoplug/plugin/AutoPlugCommandsGUI.java
@@ -49,11 +49,24 @@ public class AutoPlugCommandsGUI implements InventoryProvider {
         itemStop.setLore(Arrays.asList("Stops the server."));
         stop.setItemMeta(itemStop);
 
-        ItemStack stopBoth = new ItemStack(Material.BLACK_WOOL);
-        ItemMeta itemStopBoth = Bukkit.getItemFactory().getItemMeta(Material.BLACK_WOOL);
+        ItemStack stopBoth = new ItemStack(Material.ORANGE_WOOL);
+        ItemMeta itemStopBoth = Bukkit.getItemFactory().getItemMeta(Material.ORANGE_WOOL);
         itemStopBoth.setDisplayName(".stop both");
         itemStopBoth.setLore(Arrays.asList("Stops the server and the AutoPlug-Client."));
         stopBoth.setItemMeta(itemStopBoth);
+
+        
+        ItemStack kill = new ItemStack(Material.GRAY_WOOL);
+        ItemMeta itemKill = Bukkit.getItemFactory().getItemMeta(Material.GRAY_WOOL);
+        itemKill.setDisplayName(".kill");
+        itemKill.setLore(Arrays.asList("Kills the server."));
+        kill.setItemMeta(itemKill);
+
+        ItemStack killBoth = new ItemStack(Material.BLACK_WOOL);
+        ItemMeta itemKillBoth = Bukkit.getItemFactory().getItemMeta(Material.BLACK_WOOL);
+        itemKillBoth.setDisplayName(".kill both");
+        itemKillBoth.setLore(Arrays.asList("Kills the server and the AutoPlug-Client."));
+        killBoth.setItemMeta(itemKillBoth);
 
         contents.set(1, 1, ClickableItem.of(restart,
                 e -> {
@@ -71,6 +84,18 @@ public class AutoPlugCommandsGUI implements InventoryProvider {
                 e -> {
                     player.closeInventory();
                     Commands.stopBoth(player);
+                }));
+
+        contents.set(1, 4, ClickableItem.of(kill,
+                e -> {
+                    player.closeInventory();
+                    Commands.kill(player);
+                }));
+        
+        contents.set(1, 5, ClickableItem.of(killBoth,
+                e -> {
+                    player.closeInventory();
+                    Commands.killBoth(player);
                 }));
     }
 

--- a/src/main/java/com/osiris/autoplug/plugin/Commands.java
+++ b/src/main/java/com/osiris/autoplug/plugin/Commands.java
@@ -48,8 +48,30 @@ public class Commands {
         Constants.sendMsg(player, "Stopping the server and the AutoPlug-Client...");
         AutoPlugClientConnection.send(".stop both");
     }
+    
     public static void stopBoth(CommandSender player) {
         Constants.sendMsg(player, "Stopping the server and the AutoPlug-Client...");
         AutoPlugClientConnection.send(".stop both");
+    }
+
+    public static void kill(CommandSender player) {
+        Constants.sendMsg(player, "Killing the server...");
+        AutoPlugClientConnection.send(".kill");
+    }
+
+    
+    public static void kill(Player player) {
+        Constants.sendMsg(player, "Killing the server...");
+        AutoPlugClientConnection.send(".kill");
+    }
+    
+    public static void killBoth(Player player) {
+        Constants.sendMsg(player, "Killing the server and the AutoPlug-Client...");
+        AutoPlugClientConnection.send(".kill both");
+    }
+
+    public static void killBoth(CommandSender player) {
+        Constants.sendMsg(player, "Killing the server and the AutoPlug-Client...");
+        AutoPlugClientConnection.send(".kill both");
     }
 }

--- a/src/main/java/com/osiris/autoplug/plugin/Startup.java
+++ b/src/main/java/com/osiris/autoplug/plugin/Startup.java
@@ -80,6 +80,22 @@ public final class Startup extends JavaPlugin {
             Commands.stopBoth(sender);
             return true;
         });
+        this.getCommand(".kill").setExecutor((sender, command, label, args) -> {
+            Commands.kill(sender);
+            return true;
+        });
+        this.getCommand(".k").setExecutor((sender, command, label, args) -> {
+            Commands.kill(sender);
+            return true;
+        });
+        this.getCommand(".kill both").setExecutor((sender, command, label, args) -> {
+            Commands.killBoth(sender);
+            return true;
+        });
+        this.getCommand(".kb").setExecutor((sender, command, label, args) -> {
+            Commands.killBoth(sender);
+            return true;
+        });
         LOG.info("AutoPlug-Plugin enabled successfully.");
     }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -41,3 +41,24 @@ commands:
     description: Stops the server and the AutoPlug-Client. (Shortcut)
     usage: /.stb
     permission: autoplug.plugin.stopboth
+
+  .kill:
+    description: Kills the server.
+    usage: /.kill
+    permission: autoplug.plugin.kill
+
+  .k:
+    description: Kills the server. (Shortcut)
+    usage: /.k
+    permission: autoplug.plugin.kill
+    
+  .kill both:
+    description: Kills the server and the AutoPlug-Client.
+    usage: /.kill both
+    permission: autoplug.plugin.killboth
+
+  .kb:
+    description: Kills the server and the AutoPlug-Client. (Shortcut)
+    usage: /.kb
+    permission: autoplug.plugin.killboth
+    


### PR DESCRIPTION
This PR adds the kill command to kill the server and a command to kill both the server and AutoPlug. This is handy in case that someone made an unrecoverable mistake and you want to quickly kill the server to prevent it from autosaving and to return to the 5 minute older state (for example, someone killed all entities and you want to minimize the lost progress as much as possible when returning) or in case that something got glitched and you just need to force stop it. I have also made minor improvements to the workflow, such as adding an upload artifact action where you could download the generated JAR directly from the ZIP provided after a successful completion of the job after a push. I have also edited the README.md to include the new commands section with the kill commands and aliases being added. And at last, I have bumped the version in the pom.xml to version 1.2. These changes have been tested on a Minecraft server running Purpur 1.20.4 (Purpur is a fork of Paper, and Paper is a fork of Spigot)